### PR TITLE
Display chords and lyrics side by side

### DIFF
--- a/themes/rep/static/css/style.css
+++ b/themes/rep/static/css/style.css
@@ -11,3 +11,33 @@ footer a, footer a:visited {
     white-space: -o-pre-wrap;    /* Opera 7 */
     word-wrap: break-word;       /* Internet Explorer 5.5+ */
 }
+
+/* Side-by-side chords and lyrics layout */
+.chords-lyrics-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2rem;
+    align-items: flex-start;
+}
+.chords-col {
+    flex: 0 0 45%;
+    max-width: 520px;
+    min-width: 260px;
+}
+.chords-col img {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+.lyrics-col {
+    flex: 1 1 260px;
+    min-width: 260px;
+}
+.playlist-section {
+    max-width: 520px;
+}
+@media (max-width: 600px) {
+    .chords-lyrics-row {
+        flex-direction: column;
+    }
+}

--- a/themes/rep/templates/article.html
+++ b/themes/rep/templates/article.html
@@ -97,21 +97,23 @@
   {% endblock %}
 
   {% block content %}
-  <article class="f5 f4-ns lh-copy measure mb4">
+  <article class="f5 f4-ns lh-copy mb4">
+      <div class="chords-lyrics-row">
       {% if article.chords %}
-      <section>
+      <section class="chords-col">
         <h2 class="f2 bg-black-90 white sans-serif fw1">
           Chords
         </h2>
-        <p class="f6 f5-ns lh-copy measure i mb4">
+        <p class="f6 f5-ns lh-copy i mb4">
           <img src="{{ article.chords }}" alt="Chord chart for the jazz standard {{ article.title }}">
         </p>
       </section>
       {% endif %}
-          {{ article.content }}
+      <div class="lyrics-col">{{ article.content }}</div>
+      </div>
 
           {% if article.embed %}
-          <section>
+          <section class="playlist-section">
             <h2 class="f2 bg-black-90 white sans-serif fw1">
               Playlist
             </h2>


### PR DESCRIPTION
Hey David!  Hope this message finds you well.  Thank you for this very useful website!  I figured instead of asking you to address something, I'd just do it myself.  TLDR: I thought it might be useful to display chords and lyrics side by side so both can (theoretically) be sung and played at the same time without the need to scroll. 

Here's an example I rendered locally - cheers and happy playing! 

<img width="1735" height="1106" alt="Screenshot 2026-06-17 at 3 22 05 PM" src="https://github.com/user-attachments/assets/9ce057f4-6d45-419e-9e74-3a3158d8042b" />



## Problem
On song pages that have both a chord chart and lyrics, the chord image renders above the lyrics. This forces the reader to scroll up and down constantly to reference the chords while reading the lyrics.

## Solution
Wrap the Chords section and the article content (lyrics) in a flexbox row so they sit side by side on wide screens. The chord chart scales to fit its column; the lyrics column grows to fill the remaining space. On narrow screens (≤600 px) the layout stacks back to a single column so mobile readers are unaffected.

Also caps the Playlist section header to the same width as the chords column, so the black heading bar doesn't stretch unnecessarily wide.

## Changes
- `themes/rep/templates/article.html` — wrap chords + lyrics in `.chords-lyrics-row` flex container; add `.chords-col` / `.lyrics-col` classes; add `.playlist-section` class
- `themes/rep/static/css/style.css` — add flex layout rules and a responsive breakpoint at 600 px